### PR TITLE
Impove support for 1.4 Firewall Rules Syntax

### DIFF
--- a/changelogs/fragments/firewall_rule_cli_change_afi_version_1.4.yaml
+++ b/changelogs/fragments/firewall_rule_cli_change_afi_version_1.4.yaml
@@ -1,0 +1,4 @@
+---
+major_changes:
+  - firewall_rules - support some new firewall syntax that was added in 1.4-rolling-202308040557 (non-exhaustive)
+

--- a/tests/unit/modules/network/vyos/test_vyos_firewall_rules.py
+++ b/tests/unit/modules/network/vyos/test_vyos_firewall_rules.py
@@ -1182,3 +1182,51 @@ class TestVyosFirewallRulesModule(TestVyosModule):
             "set firewall ipv6-name INBOUND rule 101 icmpv6 type-name echo-request",
         ]
         self.execute_module(changed=True, commands=commands)
+
+    def test_vyos_firewall_new_afi_syntax_v6_rule_sets_rule_merged_01_version(self):
+        self.get_os_version.return_value = "VyOS 1.4-rolling-202308040557"
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        afi="ipv6",
+                        rule_sets=[
+                            dict(
+                                name="INBOUND",
+                                description="This is IPv6 INBOUND rule set",
+                                default_action="accept",
+                                enable_default_log=True,
+                                rules=[
+                                    dict(
+                                        number="101",
+                                        action="accept",
+                                        description="Rule 101 is configured by Ansible",
+                                        state=dict(
+                                            established=True,
+                                            related=True,
+                                            invalid=True,
+                                            new=True,
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+                state="merged",
+            ),
+        )
+        commands = [
+            "set firewall ipv6 name INBOUND default-action 'accept'",
+            "set firewall ipv6 name INBOUND description 'This is IPv6 INBOUND rule set'",
+            "set firewall ipv6 name INBOUND default-log",
+            "set firewall ipv6 name INBOUND rule 101 description 'Rule 101 is configured by Ansible'",
+            "set firewall ipv6 name INBOUND rule 101",
+            "set firewall ipv6 name INBOUND rule 101 action 'accept'",
+            "set firewall ipv6 name INBOUND rule 101 state established",
+            "set firewall ipv6 name INBOUND rule 101 state invalid",
+            "set firewall ipv6 name INBOUND rule 101 state new",
+            "set firewall ipv6 name INBOUND rule 101 state related",
+        ]
+        self.execute_module(changed=True, commands=commands)
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
A big changed happened in `1.4-rolling-202308040557`, and this collection currently cannot handle the syntax after that.  That means one cannot use current rolling releases and expect firewall rules setting to work.

I am certain this is not exhaustive, but it is a big improvement in what actually works!

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T6706

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Proposed changes
<!--- Describe your changes in detail -->
This is a non-breaking change for anything that isn't newer than `1.4-rolling-202308040557`.

## How to test
The regular expression used in this change was tested at https://regex101.com/r/gDIVEI/1

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id