### PR TITLE
Fix change detection for recent Vyos versions

### DIFF
--- a/changelogs/fragments/fix-recent-vyos-version-change-detection.yml
+++ b/changelogs/fragments/fix-recent-vyos-version-change-detection.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Fix change detection for recent Vyos versions

--- a/plugins/modules/vyos_config.py
+++ b/plugins/modules/vyos_config.py
@@ -358,7 +358,10 @@ def main():
 
     if module.params["save"]:
         diff = run_commands(module, commands=["configure", "compare saved"])[1]
-        if diff != "[edit]":
+        if diff not in {
+          "[edit]",
+          'No changes between working and saved configurations.\n\n[edit]'
+        }:
             if not module.check_mode:
                 run_commands(module, commands=["save"])
             result["changed"] = True

--- a/plugins/modules/vyos_config.py
+++ b/plugins/modules/vyos_config.py
@@ -359,8 +359,8 @@ def main():
     if module.params["save"]:
         diff = run_commands(module, commands=["configure", "compare saved"])[1]
         if diff not in {
-          "[edit]",
-          'No changes between working and saved configurations.\n\n[edit]'
+            "[edit]",
+            "No changes between working and saved configurations.\n\n[edit]"
         }:
             if not module.check_mode:
                 run_commands(module, commands=["save"])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary

Recent Vyos versions started returning this for no-change `compare saved` output:

```
No changes between working and saved configurations.

[edit]
```

instead of just `[edit]`. This causes `vyos_config` to always return a `changed` result. This PR fixes the issue by properly detecting both cases.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)

N/A

## Related PR(s)

N/A

## Proposed changes

See "Change Summary" section.

## How to test

Point my Ansible code to use a version of `vyos.vyos` with this patch in `requirements.txt`, run `ansible-galaxy install -r requirements.yml --force`, and verify that `vyos_config` now properly returns `ok` instead of `changed` when there are no changes.

```
- name: git@github.com:isundaylee/vyos.vyos.git
  type: git
  version: bug/vyos_config_changed
```

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
