### PR TITLE
T7151: chore: update fragments and galaxy

### DIFF
--- a/changelogs/fragments/0-readme.yml
+++ b/changelogs/fragments/0-readme.yml
@@ -1,3 +1,3 @@
 ---
-trivial:
+minor_changes:
   - README.md - Add Communication section with Forum information.

--- a/changelogs/fragments/6.0.0.yml
+++ b/changelogs/fragments/6.0.0.yml
@@ -1,0 +1,6 @@
+release_summary: |
+  This is the first significant release from the VyOS community for these modules.
+  This release is focussed on 1.3+ of VyOS and will be the last major release to
+  support 1.3 fully. Although efforts have been made to maintain compatibility
+  with the existing vyos collection modules, there have  breaking changes where
+  necessary to configuration parameters. Please review all changes carefully before updating.

--- a/changelogs/fragments/T151-prepare-for-release.yaml
+++ b/changelogs/fragments/T151-prepare-for-release.yaml
@@ -1,0 +1,3 @@
+trivial:
+  - update galaxy.yml for release version 6.0.0
+  - update fragments to include modules, re-align with requirements

--- a/changelogs/fragments/T6817_T6825_ovr_rep.yml
+++ b/changelogs/fragments/T6817_T6825_ovr_rep.yml
@@ -1,6 +1,8 @@
 ---
 minor_changes:
-  - fixed behavior for override and replaced states
-  - added support for packet-length-exclude for 1.4+ and the states
-  - fixed behavior for log, disable attributes
-  - added a separate test suite test_vyos_firewall_rules14.py
+  - vyos_firewall_rules - added support for packet-length-exclude for 1.4+ and the states
+bugfixes:
+  - vyos_firewall_rules - fixed behavior for override and replaced states
+  - vyos_firewall_rules - fixed behavior for log, disable attributes
+trivial:
+  - vyos_firewall_rules - added a separate test suite test_vyos_firewall_rules14.py

--- a/changelogs/fragments/T6833_fw_rules_limit.yaml
+++ b/changelogs/fragments/T6833_fw_rules_limit.yaml
@@ -1,3 +1,3 @@
 ---
-minor_changes:
-  - firewall_rules - Fix limit parameter processing
+bugfixes:
+  - vyos_firewall_rules - Fix limit parameter processing

--- a/changelogs/fragments/T6894-ntp-integration-tests.yml
+++ b/changelogs/fragments/T6894-ntp-integration-tests.yml
@@ -1,5 +1,6 @@
 ---
 minor_changes:
-  - Added ntp options for 1.5+ (interleave, ptp)
-  - Synchronized argspec and docs with core module
-  - Fix integration tests for 1.3+
+  - vyos_ntp_global - Added ntp options for 1.5+ (interleave, ptp)
+trivial:
+  - vyos_ntp_global - Synchronized argspec and docs with core module
+  - vyos_ntp_global - Fix integration tests for 1.3+

--- a/changelogs/fragments/T6987-logging-changes.yml
+++ b/changelogs/fragments/T6987-logging-changes.yml
@@ -1,15 +1,19 @@
 ---
-minor_changes:
-  - deprecating items for 1.4+ that have moved locations
-  - For 1.4, `protocol` is an attribute of the syslog host, not the facility
-  - Fixed v1.3 and before when `protocol` and `level` were set for the same host
-  - Fixed integration test for `vyos_facts` which was brittle due to line dependencies in checks
-  - Fixed integration test for `vyos_config` due to bad commands. 1.3 frequently won't finish due
-    to timeouts or system failures during the tests, but 1.4 and 1.5
-
 breaking_changes:
-  - none yet
+  - vyos_logging_global - For 1.4, `protocol` is an attribute of the syslog host, not the facility
+
+bugfixes:
+  - vyos_logging_global - Fixed v1.3 and before when `protocol` and `level` were set for the same host
+
+deprecated_features:
+  - vyos_logging_global - `protocol` is deprecated for 1.4 and later, use `facility` instead. To be removed
+    in next major version where supprot for 1.3 is removed
 
 known_issues:
   - existing code for 1.3 facility protocol and facility level are not compatible,
     only one will be set and level is the priority.
+
+trivial:
+  - vyos_logging_global - Fixed integration test for `vyos_facts` which was brittle due to line dependencies in checks
+  - vyos_logging_global - Fixed integration test for `vyos_config` due to bad commands. 1.3 frequently won't finish due
+    to timeouts or system failures during the tests, but 1.4 and 1.5

--- a/changelogs/fragments/T6988-fix-user.yml
+++ b/changelogs/fragments/T6988-fix-user.yml
@@ -1,15 +1,15 @@
 ---
 breaking_changes:
-  - removal of role/level as it was removed in 1.3
+  - vyos_user - removed level (and its alias, role) they were removed in 1.3
+  - vyos_user - explicit support for version 1.3+ only
 
 major_changes:
-  - add support for public-key authentication
-  - add support for encrypted password specification
+  - vyos_user - add support for public-key authentication
+  - vyos_user - add support for encrypted password specification
 
-minor_changes:
-  - fix sending of `full-name` to use quotes
-  - fix parsing of `full-name` to ignore quotes
-  - fix integration tests for smoke
+bugfixes:
+  - vyos_user - fix handling of `full-name` in parser and module
 
-known_issues:
-  - ssh login tests are brittle
+trivial:
+  - vyos_user - fix parsing of `full-name` to ignore quotes
+  - vyos_user - fix integration tests for smoke

--- a/changelogs/fragments/T7003-firewall-interface-integration-tests.yml
+++ b/changelogs/fragments/T7003-firewall-interface-integration-tests.yml
@@ -1,6 +1,3 @@
 ---
-minor_changes:
+trivial:
   - fix integration tests for `firewall_interfaces` for v1.3-
-
-known_issues:
-  - integration tests for `firewall_interfaces` are failing for v1.4+ as the module is deprecated in favour of firewall_rules

--- a/changelogs/fragments/T7006-interface-integration-tests.yml
+++ b/changelogs/fragments/T7006-interface-integration-tests.yml
@@ -1,8 +1,5 @@
 ---
-minor_changes:
-  - adjust for loopback being removed in `vyos_l3_interfaces`
-  - fixed `vyos_interfaces` for 1.5+
-  - update codecov updloader to version 5
-
-known_issues:
-  - integration tests for `interfaces` are still failing occasionally in 1.4 and below
+trivial:
+  - vyos interfaces tests - adjust for loopback being removed in `vyos_l3_interfaces`
+  - vyos interfaces tests - fixed `vyos_interfaces` for 1.5+
+  - actions - update codecov updloader to version 5

--- a/changelogs/fragments/T7008-l3-interface-integration-tests.yml
+++ b/changelogs/fragments/T7008-l3-interface-integration-tests.yml
@@ -1,12 +1,10 @@
 ---
-minor_changes:
-  - fix integration tests for `l3_interfaces`
-  - fix integration tests for `interfaces`
-  - fix replace in interfaces to remove vif completely if not present in new config
-  - fix override in interfaces to remove vif completely if not present in new config
-  - fix delete in interfaces to remove vif completely if in affected interface
-  - added unit test for unknown interface type
+bugfixes:
+  - vyos_l3_interfaces - fix replace in interfaces to remove vif completely if not present in new config
+  - vyos_l3_interfaces - fix override in interfaces to remove vif completely if not present in new config
+  - vyos_l3_interfaces - fix delete in interfaces to remove vif completely if in affected interface
 
-known_issues:
-  - integration tests for `interfaces` fail for 1.3 and below due to
-    mtu setting issue when a `vif` is defined.
+trivial:
+  - vyos_l3_interfaces - fix integration tests for `l3_interfaces`
+  - vyos_l3_interfaces - fix integration tests for `interfaces`
+  - vyos_l3_interfaces - added unit test for unknown interface type

--- a/changelogs/fragments/T7010-lag-interfaces-integration-tests.yaml
+++ b/changelogs/fragments/T7010-lag-interfaces-integration-tests.yaml
@@ -1,4 +1,4 @@
 ---
-minor_changes:
-  - fix integration tests for `lag_interfaces`
-  - add unit tests for `lag_interfaces`
+trivial:
+  - vyos_lag_interfaces - fix integration tests for `lag_interfaces`
+  - vyos_lag_interfaces - add unit tests for `lag_interfaces`

--- a/changelogs/fragments/T7011-lldp-integration-tests.yaml
+++ b/changelogs/fragments/T7011-lldp-integration-tests.yaml
@@ -1,9 +1,11 @@
 ---
 breaking_changes:
-  - if "address" is available, merge will cause it to be added, in contrast to
+  - lldp_global - if "address" is available, merge will cause it to be added, in contrast to
     the previous behavior where it was replaced. When used in replace mode, it
     will remove any existing addresses and replace them with the new one.
-  - civic_address is no longer a valid key (removed prior to 1.3)
+  - vyos_lldp_global - civic_address is no longer a valid key (removed prior to 1.3)
 
+deprecated_features:
+  - vyos_lldp_global - `address` is deprecated, use `addresses` instead. To be removed in 7.0.0.
 minor_changes:
-  - lldp_global address is now addresses, with appropriate coercion
+  - vyos_lldp_global -  address is now addresses, with appropriate coercion for existing address keys

--- a/changelogs/fragments/T7013_route-maps-integration-tests.yml
+++ b/changelogs/fragments/T7013_route-maps-integration-tests.yml
@@ -1,3 +1,3 @@
 ---
-minor_changes:
-  - route_maps - Refactor the integration tests structure and support for 1.4+ versions
+trivial:
+  - vyos_route_maps - Refactor the integration tests structure and support for 1.4+ versions

--- a/changelogs/fragments/T7015_static_routes_integration_tests.yaml
+++ b/changelogs/fragments/T7015_static_routes_integration_tests.yaml
@@ -1,3 +1,3 @@
 ---
-minor_changes:
-  - static_routes - Fixed for v1.3- and 1.4+
+trivial:
+  - vyos_static_routes - Fixed for v1.3- and 1.4+

--- a/changelogs/fragments/T7083_firewall_rules.yml
+++ b/changelogs/fragments/T7083_firewall_rules.yml
@@ -1,3 +1,3 @@
 ---
 breaking_changes:
-  - firewall_rules - p2p -> the code and the corresponding documentation and configuration should be removed as deprecated since 1.2
+  - vyos_firewall_rules - removed p2p options as they have been removed prior to 1.3 of VyOS

--- a/changelogs/fragments/T7127-fix-interface-integration-13.yaml
+++ b/changelogs/fragments/T7127-fix-interface-integration-13.yaml
@@ -1,3 +1,3 @@
 ---
-minor_changes:
+trivial:
   - vyos_interfaces - fix bug in RTT tests on 1.3 due to handling of MTUs

--- a/changelogs/fragments/bgp_address_family.yaml
+++ b/changelogs/fragments/bgp_address_family.yaml
@@ -1,12 +1,15 @@
 ---
 major_changes:
-  - Aligned with version 1.3+ configuration - aggregate_address, maximum_paths, network, and redistribute
-    moved from `bgp_global` module. These are now Address-family specific.
-  - Many neighbor attributes also moved from `bgp_global` to `bgp_address_family` module.
-  - Redistribute, network stanza - added support for modifiers (metric, backdoor etc as per T6829)
-  - Support for 1.3+ VyOS only
+  - vyos_bgp_address_family - Aligned with version 1.3+ configuration - aggregate_address, maximum_paths, network, and redistribute
+    moved from `bgp_global` module. These are now Address-family specific. Many neighbor attributes also moved from `vyos_bgp_global`
+    to `vyos_bgp_address_family` module.
+  - bgp modules - Added support for 1.4+ "system-as". 1.3 embedded as_number is still supported
+breaking_changes:
+  - vyos_bgp_address_family - Support for 1.3+ VyOS only
 
 minor_changes:
-  - as_number - Added support for 1.4+ "system-as. 1.3 embedded as_number is still supported"
-  - fix tests for 1.4+ bgp_address_family
-  - updated documentation
+  - vyos_bgp_address_family - Redistribute, network stanza - added support for modifiers (metric, backdoor etc as per T6829)
+
+trivial:
+  - vyos_bgp_address_family - Fixed tests for 1.4+ bgp_address_family
+  - vyos_bgp_address_family - updated documentation

--- a/changelogs/fragments/bgp_global.yaml
+++ b/changelogs/fragments/bgp_global.yaml
@@ -1,10 +1,16 @@
 ---
-minor_changes:
-  - Added support for `solo` neighbor attribute
-  - as_number - Added support for 1.4+ "system-as. 1.3 embedded as_number is still supported"
-  - Fixed tests for 1.4+ bgp_global
-  - updated documentation
-  - Aligned with version 1.3+ configuration - aggregate_address, maximum_paths, network, and redistribute
+major_changes:
+  - vyos bgp modules - Many configuration attributes moved from `bgp_global` to `bgp_address_family` module (see documentation).
+  - vyos_bgp_global - Aligned with version 1.3+ configuration - aggregate_address, maximum_paths, network, and redistribute
     Removed to `bgp_address_family` module.
-  - Many configuration attributes moved from `bgp_global` to `bgp_address_family` module.
-  - Support for 1.3+ VyOS only
+minor_changes:
+  - vyos_bgp_global - Added support for `solo` neighbor attribute
+breaking_changes:
+  - vyos_bgp_global - Support for 1.3+ VyOS only
+
+deprecated_features:
+  - vyos_bgp_global - no_ipv4_unicast - deprecated for use with VyOS 1.4+, use `ipv4_unicast` instead
+
+trivial:
+  - vyos_bgp_global - Fixed tests for 1.4+ bgp_global
+  - vyos_bgp_global - updated documentation

--- a/changelogs/fragments/cliconf.yml
+++ b/changelogs/fragments/cliconf.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - added `network_os_major_version` to facts
+  - vyos_facts - added `network_os_major_version` to facts

--- a/changelogs/fragments/firewall_global_14.yml
+++ b/changelogs/fragments/firewall_global_14.yml
@@ -1,7 +1,8 @@
 ---
 minor_changes:
-  - with 1.4+, use the the global keyword to define global firewall rules
-  - Fixed ipv6 route-redirects and tests
-  - Added support for input, output, and forward chains (1.4+)
-  - Fixed state-policy deletion (partial and full)
-  - Added support for log-level in state-policy (1.4+)
+  - vyos_firewall_global - with 1.4+, use the the global keyword to define global firewall rules
+  - vyos_firewall_global - Added support for input, output, and forward chains (1.4+)
+  - vyos_firewall_global - Added support for log-level in state-policy (1.4+)
+bugfixes:
+  - vyos_firewall_global - Fixed ipv6 route-redirects and tests
+  - vyos_firewall_global - Fixed state-policy deletion (partial and full)

--- a/changelogs/fragments/firewall_global_parsing.yml
+++ b/changelogs/fragments/firewall_global_parsing.yml
@@ -1,3 +1,3 @@
 ---
-minor_changes:
-  - Fixed parsing of global-options (1.4+)
+bugfixes:
+  - vyos_firewall_global - Fixed parsing of global-options (1.4+)

--- a/changelogs/fragments/firewall_interface_types.yml
+++ b/changelogs/fragments/firewall_interface_types.yml
@@ -1,4 +1,9 @@
 ---
 minor_changes:
-  - added support for VIF interfaces
-  - expanded firewall interface types to match existing types
+  - vyos_firewall_interfaces - added support for VIF interfaces
+  - vyos_firewall_interfaces - expanded firewall interface types to match existing types
+
+deprecated_features:
+  - vyos_firewall_interfaces - deprecated for use with VyOS 1.4+, firewalls are no longer
+    connected directly to interfaces. See the Firewall Configuration documentation
+    for how to establish a connection betwen the firewall rulesets and the flow, interface, or zone.

--- a/changelogs/fragments/firewall_rules.yml
+++ b/changelogs/fragments/firewall_rules.yml
@@ -1,8 +1,10 @@
 ---
 breaking_changes:
-  - firewall_rules - tcp.flags is now a list with an inversion flag to support 1.4+ firewall rules, but still supports 1.3-
+  - vyos_firewall_rules - tcp.flags is now a list with an inversion flag to support 1.4+ firewall rules, but still supports 1.3-
 
 minor_changes:
-  - firewall_rules - Added support for 1.4+ firewall rules
-  - fix tests for 1.4+ firewall rules (ICMP V6 code and type)
-  - added support for 1.5+ firewall `match-ipsec-in`, `match-ipsec-out`, `match-none-in`, `match-none-out`
+  - vyos_firewall_rules - Added support for 1.4+ firewall rules
+  - vyos_firewall_rules - added support for 1.5+ firewall `match-ipsec-in`, `match-ipsec-out`, `match-none-in`, `match-none-out`
+
+trivial:
+  - vyos_firewall_rules - fix tests for 1.4+ firewall rules (ICMP V6 code and type)

--- a/changelogs/fragments/fix-recent-vyos-version-change-detection.yml
+++ b/changelogs/fragments/fix-recent-vyos-version-change-detection.yml
@@ -1,3 +1,3 @@
 ---
-trivial:
-  - Fix change detection for recent Vyos versions
+bugfixes:
+  - vyos_config - Fix change detection for recent Vyos versions

--- a/changelogs/fragments/interfaces_update.yml
+++ b/changelogs/fragments/interfaces_update.yml
@@ -1,9 +1,12 @@
 ---
 minor_changes:
-  - fixed bug where 'replace' would delete an active disable and not reinstate it
-  - make l3_interfaces pick up loopback interfaces
-  - added tests for verifying both of these
-  - fixed over-zealous handling of disable, which could catch other interface
+  - vyos_l3_interfaces - make l3_interfaces pick up loopback interfaces
+  - vyos_firewall_interfaces - enable support for 1.4 firewall
+  - vyos_ospf_interaces - support for 1.4 ospf interfaces
+bugfixes:
+  - vyos_interfaces - fixed bug where 'replace' would delete an active disable and not reinstate it
+  - vyos_interfaces - fixed over-zealous handling of disable, which could catch other interface
     items that are disabled.
-  - enable support for 1.4 firewall
-  - support for 1.4 ospf
+
+trivial:
+  - vyos interface plugins - added tests for verifying imterface disable/enable

--- a/changelogs/fragments/ntp_global.yaml
+++ b/changelogs/fragments/ntp_global.yaml
@@ -1,5 +1,6 @@
 ---
 minor_changes:
-  - Added support for VyOS 1.4+ (chronyd vs ntpd)
-  - Fixed syntax for allow_client in 1.4+
-  - Added test suite for ntp_global and 1.4+
+  - vyos_ntp_global - Added support for VyOS 1.4+ (chronyd vs ntpd)
+  - vyos_ntp_global - Added syntax for allow_client in 1.4+
+trivial:
+  - vyos_ntp_global - Added test suite for ntp_global and 1.4+

--- a/changelogs/fragments/resource_updates.yml
+++ b/changelogs/fragments/resource_updates.yml
@@ -1,3 +1,3 @@
 ---
-minor_changes:
+trivial:
   - updated resources and re-ran resource templates for existing older template code

--- a/changelogs/fragments/snmp_server.yml
+++ b/changelogs/fragments/snmp_server.yml
@@ -1,10 +1,11 @@
 ---
-minor_changes:
-  - 192.0.2.1/24 (TEST-NET-1) is used on eth1 for testing to accomodate services that check
-    valid configurations (such as SNMP)
-  - use encrypted passwords for SNMPv3 tests as VyOS now converts those "when next reloaded"
-  - fixed integration tests for 1.3+ for `vyos_hostname`
 breaking_changes:
-  - parameter `engine_id` is no longer a `user` or `trap_target` parameter and is now a `snmp_v3` parameter
-  - parameters `encrypted-key` and `plaintext-key` are now `encrypted-password` and `puplaintext-password`
-    which is a breaking change with 1.2 and prior
+  - vyos_snmp_server - parameter `engine_id` is no longer a `user` or `trap_target` parameter and is now a `snmp_v3` parameter
+  - vyos_snmp_server - parameters `encrypted-key` and `plaintext-key` are now `encrypted-password` and `plaintext-password`
+  - vyos_snmp_server - no longer works with versions prior to 1.3
+
+trivial:
+  - vyos_snmp_server - 192.0.2.1/24 (TEST-NET-1) is used on eth1 for testing to accomodate services that check
+    valid configurations (such as SNMP)
+  - vyos_snmp_server - use encrypted passwords for SNMPv3 tests as VyOS now converts those "when next reloaded"
+  - vyos_snmp_server - fixed integration tests for 1.3+ for `vyos_hostname`

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ name: vyos
 description: Ansible Network Collection for VYOS devices.
 namespace: vyos
 readme: README.md
-repository: https://github.com/ansible-collections/vyos.vyos
-issues: https://github.com/ansible-collections/vyos.vyos/issues
+repository: https://github.com/vyos/vyos.vyos
+issues: https://vyos.dev
 tags: [vyos, networking]
-version: 5.0.0
+version: 6.0.0


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Update fragments and galaxy.yml for release 6.0.0

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
https://vyos.dev/T7151

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name

documentation fragments

## Proposed changes

Update documentation fragments to standards, fix galaxy.yml, prepare for 6.0.0 release.


## How to test
<!---
- [x] Sanity tests passed
- [x] Unit tests passed

Tested against VyOS versions:
<!-- examples, add or delete as appropriate; if using rolling versions, please specify
    fully
-->
- 1.3.8
- 1.4.1


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the ansible sanity and unit tests
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added unit tests to cover my changes
- [x] I have added a file to `changelogs/fragments` to describe the changes

