### PR TITLE
T7262 fix `_in_target` with `None`, replaced usages with `utils`.

### DIFF
--- a/changelogs/fragments/T7262-fix-in_target-None-check.yaml
+++ b/changelogs/fragments/T7262-fix-in_target-None-check.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - multiple modules - fix `_in_target` check for None

--- a/plugins/module_utils/network/vyos/config/firewall_global/firewall_global.py
+++ b/plugins/module_utils/network/vyos/config/firewall_global/firewall_global.py
@@ -29,6 +29,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.u
 from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.facts.facts import Facts
 from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.utils.utils import (
     list_diff_want_only,
+    _in_target,
 )
 
 from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.vyos import get_os_version
@@ -259,7 +260,7 @@ class Firewall_global(ConfigBase):
                         continue
                     if (
                         key in l_set
-                        and not self._in_target(h, key)
+                        and not _in_target(h, key)
                         and not self._is_del(l_set, h)
                     ):
                         commands.append(
@@ -374,10 +375,10 @@ class Firewall_global(ConfigBase):
                             if key == "name" and self._is_grp_del(h, want, key):
                                 commands.append(cmd + " " + want["name"])
                                 continue
-                            if not (h and self._in_target(h, key)) and not self._is_grp_del(
+                            if not (h and _in_target(h, key)) and not self._is_grp_del(
                                 h,
                                 want,
-                                key,
+                                "name",
                             ):
                                 commands.append(cmd + " " + want["name"] + " " + key)
                         elif key == "members":
@@ -502,7 +503,7 @@ class Firewall_global(ConfigBase):
                                         ),
                                     )
                                     break  # delete the whole thing and move on
-                                if (not self._in_target(h, key) or h[key] is None) and (self._in_target(w, key) and w[key]):
+                                if (not _in_target(h, key) or h[key] is None) and (_in_target(w, key) and w[key]):
                                     # delete if not being replaced and value currently exists
                                     commands.append(
                                         self._form_attr_cmd(
@@ -564,7 +565,7 @@ class Firewall_global(ConfigBase):
                                     ),
                                 )
                                 continue
-                            if not (h and self._in_target(h, key)) and not self._is_del(l_set, h):
+                            if not (h and _in_target(h, key)) and not self._is_del(l_set, h):
                                 commands.append(
                                     self._form_attr_cmd(
                                         attr=key,
@@ -696,15 +697,6 @@ class Firewall_global(ConfigBase):
         """
         return True if h and key in h and h[key] == w[key] else False
 
-    def _in_target(self, h, key):
-        """
-        This function checks whether the target exist and key present in target config.
-        :param h: target config.
-        :param key: attribute name.
-        :return: True/False.
-        """
-        return True if h and key in h else False
-
     def _is_grp_del(self, w, h, key):
         """
         This function checks whether group needed to be deleted based on
@@ -736,7 +728,7 @@ class Firewall_global(ConfigBase):
         :param key: number.
         :return: True/False.
         """
-        return key in b_set and not self._in_target(h, key)
+        return key in b_set and not _in_target(h, key)
 
     def _map_attrib(self, attrib, type=None):
         """

--- a/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
@@ -29,6 +29,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.u
 from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.facts.facts import Facts
 from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.utils.utils import (
     list_diff_want_only,
+    _in_target,
 )
 
 from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.vyos import get_os_version
@@ -309,7 +310,7 @@ class Firewall_rules(ConfigBase):
                         and (key not in h_rs or not h_rs[key])
                     ):
                         commands.append(self._add_rs_base_attrib(rs_id, key, w_rs, opr))
-                    elif not (h_rs and self._in_target(h_rs, key)):
+                    elif not (h_rs and _in_target(h_rs, key)):
                         commands.append(self._add_rs_base_attrib(rs_id, key, w_rs, opr))
             commands.extend(self._add_rules(rs_id, w_rules, h_rules, opr))
         if h_rules:
@@ -402,7 +403,7 @@ class Firewall_rules(ConfigBase):
                                 commands.extend(self._add_interface(key, w, h, cmd, opr))
                             elif (
                                 key in l_set
-                                and not (h and self._in_target(h, key))
+                                and not (h and _in_target(h, key))
                                 and not self._is_del(l_set, h)
                             ):
                                 commands.append(self._add_r_base_attrib(rs_id, key, w, opr=opr))
@@ -453,7 +454,7 @@ class Firewall_rules(ConfigBase):
                         commands.append(cmd + (" " + attr + " " + item))
                     else:
                         commands.append(cmd + (" " + attr + " " + item + " " + self._bool_to_str(val)))
-                elif not opr and item in l_set and not self._in_target(h_state, item):
+                elif not opr and item in l_set and not _in_target(h_state, item):
                     commands.append(cmd + (" " + attr + " " + item))
         return commands
 
@@ -484,7 +485,7 @@ class Firewall_rules(ConfigBase):
                 and not (h and self._is_w_same(w, h, attr))
             ):
                 commands.append(cmd + " " + attr)
-            elif not opr and not self._in_target(h_state, w[attr]):
+            elif not opr and not _in_target(h_state, w[attr]):
                 commands.append(cmd + (" " + attr + " '" + w[attr] + "'"))
 
         return commands
@@ -512,7 +513,7 @@ class Firewall_rules(ConfigBase):
                 ):
                     commands.append(cmd + (" " + attr + " " + item + " " + str(val)))
                 elif (
-                    not opr and item in l_set and not (h_recent and self._in_target(h_recent, item))
+                    not opr and item in l_set and not (h_recent and _in_target(h_recent, item))
                 ):
                     commands.append(cmd + (" " + attr + " " + item))
         return commands
@@ -554,7 +555,7 @@ class Firewall_rules(ConfigBase):
                             commands.append(cmd + (" " + "icmpv6" + " " + item + " " + str(val)))
                         else:
                             commands.append(cmd + (" " + attr + " " + item + " " + str(val)))
-                elif not opr and item in l_set and not self._in_target(h_icmp, item):
+                elif not opr and item in l_set and not _in_target(h_icmp, item):
                     commands.append(cmd + (" " + attr + " " + item.replace("_", "-") + " " + str(val)))
         return commands
 
@@ -579,7 +580,7 @@ class Firewall_rules(ConfigBase):
                         cmd
                         + (" " + attr.replace("_", "-") + " " + item.replace("_", "-") + " " + val)
                     )
-                elif not opr and item in l_set and not (h_if and self._in_target(h_if, item)):
+                elif not opr and item in l_set and not (h_if and _in_target(h_if, item)):
                     commands.append(
                         cmd + (" " + attr.replace("_", "-") + " " + item.replace("_", "-"))
                     )
@@ -766,7 +767,7 @@ class Firewall_rules(ConfigBase):
             elif (
                 not opr
                 and key in w[attr].keys()
-                and not (h and attr in h.keys() and self._in_target(h[attr], key))
+                and not (h and attr in h.keys() and _in_target(h[attr], key))
             ):
                 commands.append(cmd + (" " + attr + " " + key + " " + str(w[attr].get(key))))
             key = "rate"
@@ -827,7 +828,7 @@ class Firewall_rules(ConfigBase):
                 elif (
                     not opr
                     and key in w[attr].keys()
-                    and not (h and attr in h.keys() and self._in_target(h[attr], key))
+                    and not (h and attr in h.keys() and _in_target(h[attr], key))
                 ):
                     commands.append(cmd + (" " + attr + " " + key))
 
@@ -860,7 +861,7 @@ class Firewall_rules(ConfigBase):
                         elif (
                             not opr
                             and item in g_set
-                            and not (h_group and self._in_target(h_group, item))
+                            and not (h_group and _in_target(h_group, item))
                         ):
                             commands.append(
                                 cmd + (" " + attr + " " + key + " " + item.replace("_", "-")),
@@ -1080,7 +1081,7 @@ class Firewall_rules(ConfigBase):
         :param key: number.
         :return: True/False.
         """
-        return key in l_set and not (h and self._in_target(h, key))
+        return key in l_set and not (h and _in_target(h, key))
 
     def _is_w_same(self, w, h, key):
         """
@@ -1092,15 +1093,6 @@ class Firewall_rules(ConfigBase):
         :return: True/False.
         """
         return True if h and key in h and h[key] == w[key] else False
-
-    def _in_target(self, h, key):
-        """
-        This function checks whether the target exists and key present in target config.
-        :param h: target config.
-        :param key: attribute name.
-        :return: True/False.
-        """
-        return True if h and key in h else False
 
     def _prune_stubs(self, rs):
         if isinstance(rs, list):

--- a/plugins/module_utils/network/vyos/utils/utils.py
+++ b/plugins/module_utils/network/vyos/utils/utils.py
@@ -263,4 +263,4 @@ def _in_target(h, key):
     :param key: attribute name.
     :return: True/False.
     """
-    return True if h and key in h else False
+    return True if h and key in h and h[key] is not None else False

--- a/tests/unit/modules/network/vyos/test_vyos_firewall_global.py
+++ b/tests/unit/modules/network/vyos/test_vyos_firewall_global.py
@@ -282,7 +282,7 @@ class TestVyosFirewallGlobalModule(TestVyosModule):
                             dict(
                                 afi="ipv4",
                                 name="RND",
-                                description="This group has the Management network addresses",
+                                # Deleted the description here.
                                 members=[dict(address="192.0.2.0/24")],
                             ),
                             dict(
@@ -311,6 +311,7 @@ class TestVyosFirewallGlobalModule(TestVyosModule):
             "delete firewall group address-group RND-HOSTS address 192.0.2.5",
             "set firewall group address-group RND-HOSTS address 192.0.2.7",
             "set firewall group address-group RND-HOSTS address 192.0.2.9",
+            "delete firewall group network-group RND description",
             "delete firewall group ipv6-address-group LOCAL-v6 address fdec:2503:89d6:59b3::1",
             "set firewall group ipv6-address-group LOCAL-v6 address fdec:2503:89d6:59b3::2",
             "delete firewall group port-group SSH port 22",


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
The _in_target function doesn't check for a `None` value. This makes it impossible to delete some entities, as shown below.

I've also taken the time to rewrite usages of this function to the `utils` definition, to prevent code duplication.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7262

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
* firewall_rules
* firewall_global
* ospfv2
* ospfv3

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
On a testing VyOS:

```
configure
delete firewall
set firewall name test description test
commit
```

I expect the description to be deleted when I run this Ansible task:

```
- name: Delete description
  vyos.vyos.vyos_firewall_global:
    config:
      group:
        address_group:
        - name: test
      state: replaced
```

But nothing happens.


## Test results
<!--
Provide the output of the unit tests and confirmation of the sanity tests
along with a description of which versions of VyOS you have tested against.

Tests will be run before the PR is accepted, but do not run automatically
on forks, so please run all of the tests with each modification of your PR
to ensure they will pass.

Unit test information can be found in the [Ansible Unit Tests](https://docs.ansible.com/ansible/latest/dev_guide/testing_units.html#testing-units)
section of the documentation.

Sanity test information can be found in the [Ansible Sanity Tests](https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html#testing-sanity)
section of the Ansible documentation.

```
Example:

$ ansible-tests units
============================= test session starts ==============================
platform linux -- Python 3.12.2, pytest-8.1.1, pluggy-1.4.0
rootdir: /root/ansible_collections/vyos/vyos
configfile: ../../../ansible/test/lib/ansible_test/_data/pytest/config/default.ini
plugins: xdist-3.5.0, mock-3.14.0
created: 24/24 workers
24 workers [244 items]

........................................................................ [ 29%]
........................................................................ [ 59%]
........................................................................ [ 88%]
............................                                             [100%]
- generated xml file: /root/ansible_collections/vyos/vyos/tests/output/junit/python3.12-controller-units.xml -
============================= 244 passed in 1.55s ==============================

Describe the versions of VyOS that you have tested your changes
against.

```
-->
The tests have ran in my repo PR: https://github.com/RubenNL/vyos.vyos/pull/6
- [x] Sanity tests passed
- [x] Unit tests passed

I have also successfully ran the `firewall_global`, `firewall_rules` and `ospfv3` integration tests against `1.5-rolling-202503030030`. `ospfv2` is also affected by this change, but the integration test of this module also fails in the main branch, so I am ignoring the failure there.

Tested against VyOS versions:
<!-- examples, add or delete as appropriate; if using rolling versions, please specify
    fully
-->
- 1.5-rolling-202503030030


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the ansible sanity and unit tests
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added unit tests to cover my changes
- [x] I have added a file to `changelogs/fragments` to describe the changes