### PR TITLE
T7320: Fixed compatibility with Paramiko by removing all "null" bytes.

### DIFF
--- a/changelogs/fragments/T7320-paramiko.yaml
+++ b/changelogs/fragments/T7320-paramiko.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixed compatibility with paramiko.

--- a/plugins/cliconf/vyos.py
+++ b/plugins/cliconf/vyos.py
@@ -138,6 +138,7 @@ class Cliconf(CliconfBase):
             requests.append(cmd["command"])
         out = self.get("compare")
         out = to_text(out, errors="surrogate_or_strict")
+        out = out.replace("\u0000", "")
         diff_config = out if not out.startswith("No changes") else None
 
         if diff_config:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Fixes issue found in this comment: https://github.com/vyos/vyos.vyos/pull/407#issuecomment-2774775677

The `vyos_firewall_rules` integration test fails when using paramiko. To test this, Add ansible_network_cli_ssh_type=paramiko to your hosts.ini file, in the vars section.

I'm not 100% sure what causes this issue, but this fix shouldn't cause any issues.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7320

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos.vyos/pull/407

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
The tests with `firewall_rules` are fixed, but this affects all components.

## Proposed changes
<!--- Describe your changes in detail -->
Remove all null bytes from the ssh output.

I haven't added any tests, because this is (I think) impossible to test.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
As described above.

## Test results
<!--
Provide the output of the unit tests and confirmation of the sanity tests
along with a description of which versions of VyOS you have tested against.

Tests will be run before the PR is accepted, but do not run automatically
on forks, so please run all of the tests with each modification of your PR
to ensure they will pass.

Unit test information can be found in the [Ansible Unit Tests](https://docs.ansible.com/ansible/latest/dev_guide/testing_units.html#testing-units)
section of the documentation.

Sanity test information can be found in the [Ansible Sanity Tests](https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html#testing-sanity)
section of the Ansible documentation.

```
Example:

$ ansible-tests units
============================= test session starts ==============================
platform linux -- Python 3.12.2, pytest-8.1.1, pluggy-1.4.0
rootdir: /root/ansible_collections/vyos/vyos
configfile: ../../../ansible/test/lib/ansible_test/_data/pytest/config/default.ini
plugins: xdist-3.5.0, mock-3.14.0
created: 24/24 workers
24 workers [244 items]

........................................................................ [ 29%]
........................................................................ [ 59%]
........................................................................ [ 88%]
............................                                             [100%]
- generated xml file: /root/ansible_collections/vyos/vyos/tests/output/junit/python3.12-controller-units.xml -
============================= 244 passed in 1.55s ==============================

Describe the versions of VyOS that you have tested your changes
against.

```
-->
- [x] Sanity tests passed
- [x] Unit tests passed

Tested against VyOS versions:
<!-- examples, add or delete as appropriate; if using rolling versions, please specify
    fully
-->
Unit test results are shown here: https://github.com/RubenNL/vyos.vyos/actions/runs/14267342846
- 1.3.4 (I know, not supported, but I don't have a license for anything else. I just had this one laying around from a long time ago)
- 1.5-rolling-202503030030


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the ansible sanity and unit tests
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added unit tests to cover my changes
- [x] I have added a file to `changelogs/fragments` to describe the changes

