### PR TITLE
T7238 Fix integration tests for vyos_logging_global for 1.5

### DIFF
--- a/tests/integration/targets/vyos_logging_global/tests/cli/_get_version.yaml
+++ b/tests/integration/targets/vyos_logging_global/tests/cli/_get_version.yaml
@@ -25,4 +25,10 @@
 
 - name: include correct vars
   include_vars: v1_4.yaml
-  when: vyos_version is version('1.4.0', '>=', version_type='semver')
+  when:
+    - vyos_version is version('1.4.0', '>=', version_type='semver')
+    - vyos_version is version('1.5.0', '<', version_type='semver')
+
+- name: include correct vars
+  include_vars: v1_5.yaml
+  when: vyos_version is version('1.5.0', '>=', version_type='semver')

--- a/tests/integration/targets/vyos_logging_global/tests/cli/_populate.yaml
+++ b/tests/integration/targets/vyos_logging_global/tests/cli/_populate.yaml
@@ -1,5 +1,6 @@
 ---
 - ansible.builtin.include_tasks: _remove_config.yaml
+- ansible.builtin.include_tasks: _get_version.yaml
 
 - name: POPULATE Apply the provided configuration
   register: result
@@ -29,7 +30,7 @@
               severity: debug
             - facility: local6
               severity: alert
-        - username: paul
+        - username: vyos
           facilities:
             - facility: local7
               severity: err

--- a/tests/integration/targets/vyos_logging_global/vars/pre-v1_4.yaml
+++ b/tests/integration/targets/vyos_logging_global/vars/pre-v1_4.yaml
@@ -43,7 +43,6 @@ overridden:
     - delete system syslog global facility local7
     - delete system syslog host 172.16.2.12
     - delete system syslog host 172.16.2.15
-    - delete system syslog user paul
     - delete system syslog user vyos
 
   after:

--- a/tests/integration/targets/vyos_logging_global/vars/v1_4.yaml
+++ b/tests/integration/targets/vyos_logging_global/vars/v1_4.yaml
@@ -47,7 +47,6 @@ overridden:
     - delete system syslog host 172.16.2.15 protocol udp
     - delete system syslog host 172.16.2.12
     - delete system syslog host 172.16.2.15
-    - delete system syslog user paul
     - delete system syslog user vyos
 
   after:

--- a/tests/integration/targets/vyos_logging_global/vars/v1_5.yaml
+++ b/tests/integration/targets/vyos_logging_global/vars/v1_5.yaml
@@ -1,0 +1,73 @@
+---
+host_172_16_2_15: &host_172_16_2_15
+  - hostname: 172.16.2.15
+    facilities:
+      - facility: all
+        severity: all
+    protocol: tcp
+
+merged:
+  before: {}
+  commands:
+    - set system syslog host 172.16.2.15 facility all level all
+    - set system syslog host 172.16.2.15 protocol tcp
+    - set system syslog console facility all
+    - set system syslog user vyos facility local7 level debug
+    - set system syslog global facility cron level debug
+    - set system syslog file def archive file 2
+    - set system syslog file def facility local6 level emerg
+  after:
+    console:
+      facilities:
+        - facility: all
+    files:
+      - path: def
+        facilities:
+          - facility: local6
+            severity: emerg
+        archive:
+          file_num: 2
+    hosts: *host_172_16_2_15
+    users:
+      - username: vyos
+        facilities:
+          - facility: local7
+            severity: debug
+    global_params:
+      facilities:
+        - facility: cron
+          severity: debug
+
+overridden:
+  commands:
+    - delete system syslog file def
+    - delete system syslog global facility cron
+    - delete system syslog global facility local7
+    - delete system syslog host 172.16.2.12 protocol udp
+    - delete system syslog host 172.16.2.15 protocol udp
+    - delete system syslog host 172.16.2.12
+    - delete system syslog host 172.16.2.15
+    - delete system syslog user vyos
+
+  after:
+    console:
+      facilities:
+        - facility: all
+        - facility: local7
+          severity: err
+        - facility: news
+          severity: debug
+    files:
+      - path: Myfile
+
+populate_logging_global_hosts:
+  - hostname: 172.16.2.15
+    facilities:
+      - facility: all
+        severity: all
+      - facility: all
+    protocol: udp
+  - hostname: 172.16.2.12
+    facilities:
+      - facility: all
+    protocol: udp


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Test results
<!--
Provide the output of the unit tests and confirmation of the sanity tests
along with a description of which versions of VyOS you have tested against.

Tests will be run before the PR is accepted, but do not run automatically
on forks, so please run all of the tests with each modification of your PR
to ensure they will pass.

Unit test information can be found in the [Ansible Unit Tests](https://docs.ansible.com/ansible/latest/dev_guide/testing_units.html#testing-units)
section of the documentation.

Sanity test information can be found in the [Ansible Sanity Tests](https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html#testing-sanity)
section of the Ansible documentation.

```
Example:

$ ansible-tests units
============================= test session starts ==============================
platform linux -- Python 3.12.2, pytest-8.1.1, pluggy-1.4.0
rootdir: /root/ansible_collections/vyos/vyos
configfile: ../../../ansible/test/lib/ansible_test/_data/pytest/config/default.ini
plugins: xdist-3.5.0, mock-3.14.0
created: 24/24 workers
24 workers [244 items]

........................................................................ [ 29%]
........................................................................ [ 59%]
........................................................................ [ 88%]
............................                                             [100%]
- generated xml file: /root/ansible_collections/vyos/vyos/tests/output/junit/python3.12-controller-units.xml -
============================= 244 passed in 1.55s ==============================

Describe the versions of VyOS that you have tested your changes
against.

```
-->
- [ ] Sanity tests passed
- [ ] Unit tests passed

Tested against VyOS versions:
<!-- examples, add or delete as appropriate; if using rolling versions, please specify
    fully
-->
- 1.3.8
- 1.4-rolling-202201010100


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the ansible sanity and unit tests
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added unit tests to cover my changes
- [ ] I have added a file to `changelogs/fragments` to describe the changes

