### PR TITLE
TestModule profile patch

### DIFF
--- a/changelogs/fragments/test_module_patch.yml
+++ b/changelogs/fragments/test_module_patch.yml
@@ -1,0 +1,3 @@
+---
+trvial:
+  - util.py - Add mock _ANSIBLE_PROFILE to reflect changes to Ansible libs

--- a/changelogs/fragments/test_module_patch.yml
+++ b/changelogs/fragments/test_module_patch.yml
@@ -1,3 +1,3 @@
 ---
-trvial:
+trivial:
   - util.py - Add mock _ANSIBLE_PROFILE to reflect changes to Ansible libs

--- a/tests/unit/modules/utils.py
+++ b/tests/unit/modules/utils.py
@@ -20,6 +20,9 @@ def set_module_args(args):
     args = json.dumps({"ANSIBLE_MODULE_ARGS": args})
     basic._ANSIBLE_ARGS = to_bytes(args)
 
+    profile = "legacy"
+    basic._ANSIBLE_PROFILE = profile
+
 
 class AnsibleExitJson(Exception):
     pass


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
test/module/utils.py

## Proposed changes
<!--- Describe your changes in detail -->
Recent update to Ansible code base resulted in cascade unit test failing with the errors as in the example:
`.tox/unit-py3.11-devel/lib/python3.11/site-packages/ansible/module_utils/basic.py:1216: in _load_params
    self.params = _load_params()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def _load_params():
        """ read the modules parameters and store them globally.
    
        This function may be needed for certain very dynamic custom modules which
        want to process the parameters that are being handed the module.  Since
        this is so closely tied to the implementation of modules we cannot
        guarantee API stability for it (it may change between versions) however we
        will try not to break it gratuitously.  It is certainly more future-proof
        to call this function and consume its outputs than to implement the logic
        inside it as a copy in your own code.
        """
        global _ANSIBLE_ARGS, _ANSIBLE_PROFILE
    
        if _ANSIBLE_ARGS is None:
            _ANSIBLE_ARGS, _ANSIBLE_PROFILE = _debugging.load_params()
    
        buffer = _ANSIBLE_ARGS
        profile = _ANSIBLE_PROFILE
    
        if not profile:
>           raise Exception("No serialization profile was specified.")
E           Exception: No serialization profile was specified.

.tox/unit-py3.11-devel/lib/python3.11/site-packages/ansible/module_utils/basic.py:334: Exception`

The change mocks the missing _ANSIBLE_PROFILE

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

## Test results
<!--
Provide the output of the unit tests and confirmation of the sanity tests
along with a description of which versions of VyOS you have tested against.

Tests will be run before the PR is accepted, but do not run automatically
on forks, so please run all of the tests with each modification of your PR
to ensure they will pass.

Unit test information can be found in the [Ansible Unit Tests](https://docs.ansible.com/ansible/latest/dev_guide/testing_units.html#testing-units)
section of the documentation.

Sanity test information can be found in the [Ansible Sanity Tests](https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html#testing-sanity)
section of the Ansible documentation.

```
Example:

$ ansible-tests units
============================= test session starts ==============================
platform linux -- Python 3.12.2, pytest-8.1.1, pluggy-1.4.0
rootdir: /root/ansible_collections/vyos/vyos
configfile: ../../../ansible/test/lib/ansible_test/_data/pytest/config/default.ini
plugins: xdist-3.5.0, mock-3.14.0
created: 24/24 workers
24 workers [244 items]

........................................................................ [ 29%]
........................................................................ [ 59%]
........................................................................ [ 88%]
............................                                             [100%]
- generated xml file: /root/ansible_collections/vyos/vyos/tests/output/junit/python3.12-controller-units.xml -
============================= 244 passed in 1.55s ==============================

Describe the versions of VyOS that you have tested your changes
against.

```
-->
- [x] Sanity tests passed
- [x] Unit tests passed

Tested against VyOS versions:
<!-- examples, add or delete as appropriate; if using rolling versions, please specify
    fully
-->
N/A


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the ansible sanity and unit tests
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added unit tests to cover my changes
- [x] I have added a file to `changelogs/fragments` to describe the changes

