### PR TITLE
T7496 Fix disabling src route

### DIFF
--- a/changelogs/fragments/T7496_firewall_global_fix_disabling_src_route.yml
+++ b/changelogs/fragments/T7496_firewall_global_fix_disabling_src_route.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vyos_firewall_global - Fix disabling src route

--- a/plugins/module_utils/network/vyos/config/firewall_global/firewall_global.py
+++ b/plugins/module_utils/network/vyos/config/firewall_global/firewall_global.py
@@ -550,7 +550,7 @@ class Firewall_global(ConfigBase):
                         afi = None
                     afi = None
                 for key, val in iteritems(w):
-                    if val and key != "afi":
+                    if val is not None and key != "afi":
                         if opr and key in l_set and not (h and self._is_w_same(w, h, key)):
                             commands.append(
                                 self._form_attr_cmd(

--- a/tests/unit/modules/network/vyos/test_vyos_firewall_global.py
+++ b/tests/unit/modules/network/vyos/test_vyos_firewall_global.py
@@ -109,7 +109,7 @@ class TestVyosFirewallGlobalModule(TestVyosModule):
                         ),
                         dict(
                             afi="ipv6",
-                            ip_src_route=True,
+                            ip_src_route=False,
                             icmp_redirects=dict(receive=False),
                         ),
                     ],
@@ -183,6 +183,7 @@ class TestVyosFirewallGlobalModule(TestVyosModule):
             "set firewall group port-group TELNET description 'This group has the telnet ports'",
             "set firewall group port-group TELNET",
             "set firewall ip-src-route 'enable'",
+            "set firewall ipv6-src-route 'disable'",
             "set firewall receive-redirects 'disable'",
             "set firewall config-trap 'enable'",
             "set firewall ipv6-receive-redirects 'disable'",

--- a/tests/unit/modules/network/vyos/test_vyos_firewall_global14.py
+++ b/tests/unit/modules/network/vyos/test_vyos_firewall_global14.py
@@ -109,7 +109,7 @@ class TestVyosFirewallRulesModule14(TestVyosModule):
                         ),
                         dict(
                             afi="ipv6",
-                            ip_src_route=True,
+                            ip_src_route=False,
                             icmp_redirects=dict(receive=False),
                         ),
                     ],
@@ -185,6 +185,7 @@ class TestVyosFirewallRulesModule14(TestVyosModule):
             "set firewall global-options ip-src-route 'enable'",
             "set firewall global-options receive-redirects 'disable'",
             "set firewall global-options config-trap 'enable'",
+            "set firewall global-options ipv6-src-route 'disable'",
             "set firewall global-options ipv6-receive-redirects 'disable'",
             "set firewall global-options state-policy established action 'accept'",
             "set firewall global-options state-policy established log",


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed disabling src route.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7496

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
firewall(_global)

## Proposed changes
<!--- Describe your changes in detail -->
Fixed the ability to disable the src_route.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->

First:

```yml
- vyos.vyos.vyos_firewall_global:
    config:
      route_redirects:
      - afi: ipv6
        ip_src_route: true
```
Then:
```yml
- vyos.vyos.vyos_firewall_global:
    config:
      route_redirects:
      - afi: ipv6
        ip_src_route: false
```
Observe: ipv6-src-route is still specified in the config as true.

## Test results
<!--
Provide the output of the unit tests and confirmation of the sanity tests
along with a description of which versions of VyOS you have tested against.

Tests will be run before the PR is accepted, but do not run automatically
on forks, so please run all of the tests with each modification of your PR
to ensure they will pass.

Unit test information can be found in the [Ansible Unit Tests](https://docs.ansible.com/ansible/latest/dev_guide/testing_units.html#testing-units)
section of the documentation.

Sanity test information can be found in the [Ansible Sanity Tests](https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html#testing-sanity)
section of the Ansible documentation.

```
Example:

$ ansible-tests units
============================= test session starts ==============================
platform linux -- Python 3.12.2, pytest-8.1.1, pluggy-1.4.0
rootdir: /root/ansible_collections/vyos/vyos
configfile: ../../../ansible/test/lib/ansible_test/_data/pytest/config/default.ini
plugins: xdist-3.5.0, mock-3.14.0
created: 24/24 workers
24 workers [244 items]

........................................................................ [ 29%]
........................................................................ [ 59%]
........................................................................ [ 88%]
............................                                             [100%]
- generated xml file: /root/ansible_collections/vyos/vyos/tests/output/junit/python3.12-controller-units.xml -
============================= 244 passed in 1.55s ==============================

Describe the versions of VyOS that you have tested your changes
against.

```
-->
- [x] Sanity tests passed
- [x] Unit tests passed

The test results can be seen here:  
failing: https://github.com/RubenNL/vyos.vyos/actions/runs/15301976749  
succeeding: https://github.com/RubenNL/vyos.vyos/actions/runs/15302043258

Tested against VyOS versions:
<!-- examples, add or delete as appropriate; if using rolling versions, please specify
    fully
-->
- 1.4.2 (only tested this bugfix, I still haven't received a open-source license)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the ansible sanity and unit tests
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added unit tests to cover my changes
- [x] I have added a file to `changelogs/fragments` to describe the changes

