### PR TITLE
Revert "T7320: Fixed compatibility with Paramiko by removing all "null" bytes."

### DIFF
--- a/changelogs/fragments/T7320-paramiko.yaml
+++ b/changelogs/fragments/T7320-paramiko.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - Fixed compatibility with paramiko.

--- a/plugins/cliconf/vyos.py
+++ b/plugins/cliconf/vyos.py
@@ -138,7 +138,6 @@ class Cliconf(CliconfBase):
             requests.append(cmd["command"])
         out = self.get("compare")
         out = to_text(out, errors="surrogate_or_strict")
-        out = out.replace("\u0000", "")
         diff_config = out if not out.startswith("No changes") else None
 
         if diff_config:


### PR DESCRIPTION
Reverts vyos/vyos.vyos#409 as per @gaige's request.