### PR TITLE
T9220: ci: upload JUnit test results to Codecov Test Analytics (probe)

### DIFF
--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -74,6 +74,7 @@ jobs:
         if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && github.actor != 'dependabot[bot]' }}
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         timeout-minutes: 5
+        continue-on-error: true
         with:
           report_type: test_results
           files: ${{ steps.identify.outputs.collection_path }}/test-results/junit-codecoverage-codecoverage-pytest-s0.xml

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run Coverage tests
         run: |
-          pytest tests/unit -v --cov-report xml --cov=./
+          pytest tests/unit -v --cov-report xml --cov=./ --junitxml=test-results/junit-codecoverage-codecoverage-pytest-s0.xml
         working-directory: ${{ steps.identify.outputs.collection_path }}
 
       - name: Upload coverage report to Codecov
@@ -69,3 +69,16 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && github.actor != 'dependabot[bot]' }}
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+        timeout-minutes: 5
+        with:
+          report_type: test_results
+          files: ${{ steps.identify.outputs.collection_path }}/test-results/junit-codecoverage-codecoverage-pytest-s0.xml
+          disable_search: true
+          fail_ci_if_error: false
+          flags: unit-pytest-s0
+          name: unit-pytest-s0
+          version: v11.3.1

--- a/.github/workflows/codecoverage.yml
+++ b/.github/workflows/codecoverage.yml
@@ -71,7 +71,11 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && github.actor != 'dependabot[bot]' }}
+        if: >-
+          ${{ !cancelled() &&
+              (github.event_name != 'pull_request' ||
+               github.event.pull_request.head.repo.fork == false) &&
+              github.actor != 'dependabot[bot]' }}
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         timeout-minutes: 5
         continue-on-error: true


### PR DESCRIPTION
## Summary

Public-class PF-B probe for the Codecov Test Analytics fleet rollout (T9220):

- `pytest` now emits JUnit XML (`--junitxml=test-results/junit-codecoverage-codecoverage-pytest-s0.xml`, under the collection working directory)
- New pinned upload step: `codecov/codecov-action@v5.5.5` (pinned by commit SHA) with `report_type: test_results`, explicit `files:`, `disable_search: true`, `fail_ci_if_error: false`, tokenless (public-repo path), CLI pinned `v11.3.1`
- Upload runs on test failure too (`!cancelled()`), guarded against fork-PR and Dependabot contexts until those upload modes are empirically proven
- Existing `codecov-action@v7` coverage upload untouched

Informational only — no required checks, no gating. Probe acceptance evidence (JUnit testcase count, upload receipt, Test Analytics dashboard ingestion for this head SHA) will be recorded on the tracking tickets before merge.

Advances: IS-658

🤖 Generated by [robots](https://vyos.io)