### PR TITLE
T9251: accept OpenSSH sk-* key types in vyos_user

### DIFF
--- a/changelogs/fragments/T9251_vyos_user_sk_key_types.yml
+++ b/changelogs/fragments/T9251_vyos_user_sk_key_types.yml
@@ -1,3 +1,3 @@
 ---
-minor_changes:
-  - vyos_user - Accept the OpenSSH security key types ``sk-ecdsa-sha2-nistp256@openssh.com`` and ``sk-ssh-ed25519@openssh.com`` for ``public_keys.type``, matching the types VyOS itself allows.
+bugfixes:
+  - vyos_user - Accept the OpenSSH security key types ``sk-ecdsa-sha2-nistp256@openssh.com`` and ``sk-ssh-ed25519@openssh.com`` for ``public_keys.type``, which VyOS accepts but the module rejected.

--- a/changelogs/fragments/T9251_vyos_user_sk_key_types.yml
+++ b/changelogs/fragments/T9251_vyos_user_sk_key_types.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - vyos_user - Accept the OpenSSH security key types ``sk-ecdsa-sha2-nistp256@openssh.com`` and ``sk-ssh-ed25519@openssh.com`` for ``public_keys.type``, matching the types VyOS itself allows.

--- a/plugins/modules/vyos_user.py
+++ b/plugins/modules/vyos_user.py
@@ -117,6 +117,8 @@ options:
             - ecdsa-sha2-nistp384
             - ssh-ed25519
             - ecdsa-sha2-nistp521
+            - sk-ecdsa-sha2-nistp256@openssh.com
+            - sk-ssh-ed25519@openssh.com
 
   name:
     description:
@@ -447,6 +449,8 @@ def main():
                 "ecdsa-sha2-nistp384",
                 "ssh-ed25519",
                 "ecdsa-sha2-nistp521",
+                "sk-ecdsa-sha2-nistp256@openssh.com",
+                "sk-ssh-ed25519@openssh.com",
             ],
         ),
     )

--- a/tests/unit/modules/network/vyos/test_vyos_user.py
+++ b/tests/unit/modules/network/vyos/test_vyos_user.py
@@ -170,15 +170,20 @@ class TestVyosUserModule(TestVyosModule):
             ],
         )
 
-    def test_vyos_user_set_security_key(self):
+    def test_vyos_user_set_security_keys(self):
         set_module_args(
             dict(
                 name="ansible",
                 public_keys=[
                     dict(
-                        name="user@host",
+                        name="ecdsa@host",
                         key="AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTY",
                         type="sk-ecdsa-sha2-nistp256@openssh.com",
+                    ),
+                    dict(
+                        name="ed25519@host",
+                        key="AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIFIR0jrMvBdmvTJNY5EDhOD",
+                        type="sk-ssh-ed25519@openssh.com",
                     ),
                 ],
             ),
@@ -187,8 +192,10 @@ class TestVyosUserModule(TestVyosModule):
         self.assertEqual(
             result["commands"],
             [
-                "set system login user ansible authentication public-keys user@host key 'AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTY'",
-                "set system login user ansible authentication public-keys user@host type 'sk-ecdsa-sha2-nistp256@openssh.com'",
+                "set system login user ansible authentication public-keys ecdsa@host key 'AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTY'",
+                "set system login user ansible authentication public-keys ecdsa@host type 'sk-ecdsa-sha2-nistp256@openssh.com'",
+                "set system login user ansible authentication public-keys ed25519@host key 'AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIFIR0jrMvBdmvTJNY5EDhOD'",
+                "set system login user ansible authentication public-keys ed25519@host type 'sk-ssh-ed25519@openssh.com'",
             ],
         )
 

--- a/tests/unit/modules/network/vyos/test_vyos_user.py
+++ b/tests/unit/modules/network/vyos/test_vyos_user.py
@@ -170,6 +170,28 @@ class TestVyosUserModule(TestVyosModule):
             ],
         )
 
+    def test_vyos_user_set_security_key(self):
+        set_module_args(
+            dict(
+                name="ansible",
+                public_keys=[
+                    dict(
+                        name="user@host",
+                        key="AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTY",
+                        type="sk-ecdsa-sha2-nistp256@openssh.com",
+                    ),
+                ],
+            ),
+        )
+        result = self.execute_module(changed=True)
+        self.assertEqual(
+            result["commands"],
+            [
+                "set system login user ansible authentication public-keys user@host key 'AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTY'",
+                "set system login user ansible authentication public-keys user@host type 'sk-ecdsa-sha2-nistp256@openssh.com'",
+            ],
+        )
+
     def test_vyos_user_set_ssh_key_idempotent(self):
         set_module_args(
             dict(


### PR DESCRIPTION
## Change Summary
Add the two OpenSSH security key types to the `public_keys.type` choices in `vyos_user`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Task(s)
* https://vyos.dev/T9251

## Related PR(s)

## Component(s) name
vyos_user

## Proposed changes
VyOS has accepted `sk-ecdsa-sha2-nistp256@openssh.com` and `sk-ssh-ed25519@openssh.com` since T4750, but the module's choices list was never updated, so a playbook using a security key fails argspec validation while the equivalent CLI commands succeed. Both types are appended to the `DOCUMENTATION` choices and to `public_key_spec`; existing choices are untouched.

## How to test

## Test results
```
$ ansible-test units --local --python 3.13
Unit test controller with Python 3.13
============================= test session starts ==============================
platform linux -- Python 3.13.11, pytest-9.1.1, pluggy-1.6.0
rootdir: /tmp/claude-1000/-home-mson-src-github-vyos-vyos/82a9339b-3c75-42ba-941a-8a437723d4b3/scratchpad/collections/ansible_collections/vyos/vyos
configfile: ../../../../.venv/lib/python3.13/site-packages/ansible_test/_data/pytest/config/default.ini
plugins: xdist-3.8.0
created: 12/12 workers
12 workers [553 items]

........................................................................ [ 13%]
........................................................................ [ 26%]
........................................................................ [ 39%]
........................................................................ [ 52%]
........................................................................ [ 65%]
........................................................................ [ 78%]
........................................................................ [ 91%]
.................................................                        [100%]
- generated xml file: /tmp/claude-1000/-home-mson-src-github-vyos-vyos/82a9339b-3c75-42ba-941a-8a437723d4b3/scratchpad/collections/ansible_collections/vyos/vyos/tests/output/junit/python3.13-controller-units.xml -
============================= 553 passed in 18.40s =============================
```
- [x] Sanity tests passed
- [x] Unit tests passed

Not tested against a live image; the change is to argument validation only.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the ansible sanity and unit tests
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added unit tests to cover my changes
- [x] I have added a file to `changelogs/fragments` to describe the changes
